### PR TITLE
feat: add httpClientConfig to define external api interceptors and overrides

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -44,6 +44,7 @@ export default class Client {
     setSession,
     getSession,
     prefixPath = "/lib",
+    apiConfig,
   }: TClientOptions) {
     if (!serverUrl) throw "serverUrl is required.";
     const arkeHttpClient = new HttpClient({
@@ -51,6 +52,7 @@ export default class Client {
       prefixPath,
       project,
       getSession,
+      apiConfig,
     }).instance;
 
     this.serverUrl = serverUrl;
@@ -85,6 +87,7 @@ export default class Client {
       baseUrl: serverUrl,
       project,
       getSession,
+      apiConfig,
     }).instance;
   }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -44,7 +44,7 @@ export default class Client {
     setSession,
     getSession,
     prefixPath = "/lib",
-    apiConfig,
+    httpClientConfig,
   }: TClientOptions) {
     if (!serverUrl) throw "serverUrl is required.";
     const arkeHttpClient = new HttpClient({
@@ -52,7 +52,7 @@ export default class Client {
       prefixPath,
       project,
       getSession,
-      apiConfig,
+      httpClientConfig,
     }).instance;
 
     this.serverUrl = serverUrl;
@@ -87,7 +87,7 @@ export default class Client {
       baseUrl: serverUrl,
       project,
       getSession,
-      apiConfig,
+      httpClientConfig,
     }).instance;
   }
 }

--- a/src/network/api/lib/HttpClient.ts
+++ b/src/network/api/lib/HttpClient.ts
@@ -29,7 +29,7 @@ class HttpClient {
     getSession,
     timeout,
     headers,
-    apiConfig,
+    httpClientConfig,
   }: THttpClientOptions) {
     const baseURL = `${baseUrl}${prefixPath ?? ""}`;
 
@@ -64,7 +64,7 @@ class HttpClient {
       (error) => Promise.reject(error)
     );
 
-    if (apiConfig) apiConfig(this.instance);
+    if (httpClientConfig) httpClientConfig(this.instance);
   }
 }
 

--- a/src/network/api/lib/HttpClient.ts
+++ b/src/network/api/lib/HttpClient.ts
@@ -29,6 +29,7 @@ class HttpClient {
     getSession,
     timeout,
     headers,
+    apiConfig,
   }: THttpClientOptions) {
     const baseURL = `${baseUrl}${prefixPath ?? ""}`;
 
@@ -57,10 +58,13 @@ class HttpClient {
         }
         if (project && config.headers && !config.headers["Arke-Project-Key"])
           config.headers["Arke-Project-Key"] = project;
+
         return config;
       },
       (error) => Promise.reject(error)
     );
+
+    if (apiConfig) apiConfig(this.instance);
   }
 }
 

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -16,6 +16,7 @@
 
 import { TSignInResponseData } from "./auth";
 import { TToken } from "./auth";
+import { AxiosInstance } from "axios/index";
 
 type TClientOptions = {
   serverUrl?: string | undefined;
@@ -23,6 +24,7 @@ type TClientOptions = {
   getSession?(): Promise<string | TToken | null>;
   setSession?(session: TSignInResponseData): void;
   prefixPath?: string;
+  apiConfig?(api: AxiosInstance): AxiosInstance;
 };
 
 export type { TClientOptions };

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -24,7 +24,7 @@ type TClientOptions = {
   getSession?(): Promise<string | TToken | null>;
   setSession?(session: TSignInResponseData): void;
   prefixPath?: string;
-  apiConfig?(api: AxiosInstance): AxiosInstance;
+  httpClientConfig?(api: AxiosInstance): AxiosInstance;
 };
 
 export type { TClientOptions };

--- a/src/types/httpClient.ts
+++ b/src/types/httpClient.ts
@@ -24,7 +24,7 @@ type THttpClientOptions = {
   getSession?: () => Promise<string | TToken | null>;
   headers?: AxiosRequestHeaders | undefined;
   timeout?: number;
-  apiConfig?(api: AxiosInstance): AxiosInstance;
+  httpClientConfig?(api: AxiosInstance): AxiosInstance;
 };
 
 export type { THttpClientOptions };

--- a/src/types/httpClient.ts
+++ b/src/types/httpClient.ts
@@ -15,7 +15,7 @@
  */
 
 import { TToken } from "./auth";
-import { AxiosRequestHeaders } from "axios";
+import { AxiosInstance, AxiosRequestHeaders } from "axios";
 
 type THttpClientOptions = {
   baseUrl: string;
@@ -24,6 +24,7 @@ type THttpClientOptions = {
   getSession?: () => Promise<string | TToken | null>;
   headers?: AxiosRequestHeaders | undefined;
   timeout?: number;
+  apiConfig?(api: AxiosInstance): AxiosInstance;
 };
 
 export type { THttpClientOptions };


### PR DESCRIPTION
# Description

With `apiConfig` (we can change callback name) is now possible extend the api initialization. At the moment the interceptors defined outside the library doesn't work. With this new callback is now possible define and overrides the internal interceptors, it can be useful to manage general toast messages with status code: 

```
// Init Arke Client
new Client({
    ...
    apiConfig: (api: AxiosInstance) => {
      api.interceptors.request.use((config) => config);
      api.interceptors.response.use(
        (config) => {
          return config;
        },
        (err) => {
          if (err.response.status === HTTPStatusCode.InternalServerError) {
            // Show toast message on application
            toast.error(err.message);
          }
          return Promise.reject(err);
        }
      );
      return api;
    },
  });
```