### PR TITLE
feat: extend relational operator isnull and not

### DIFF
--- a/src/__tests__/filter.test.ts
+++ b/src/__tests__/filter.test.ts
@@ -43,6 +43,11 @@ const mockConditionalIsNullFilter = new Filter({
   key: "value",
 });
 
+const mockConditionalIsNotFilter = new Filter({
+  operator: RelationalOperator.NOT,
+  value: mockConditionalIsNullFilter.toString(),
+});
+
 describe("Filter", () => {
   it("should create correct RelationalFilter instance", () => {
     expect(mockRelationalFilter.filters).toBeUndefined();
@@ -75,7 +80,7 @@ describe("Filter", () => {
   });
 
   it("should ConditionalFilter toString should work properly with not", () => {
-    expect(mockConditionalIsNullFilter.toString()).toBe("isnot(isnull(value))");
+    expect(mockConditionalIsNotFilter.toString()).toBe("not(isnull(value))");
   });
 
   it("should get length of the filters", () => {

--- a/src/__tests__/filter.test.ts
+++ b/src/__tests__/filter.test.ts
@@ -38,6 +38,11 @@ const mockConditionalEmptyFilter = new Filter({
   filters: [],
 });
 
+const mockConditionalIsNullFilter = new Filter({
+  operator: RelationalOperator.ISNULL,
+  key: "value",
+});
+
 describe("Filter", () => {
   it("should create correct RelationalFilter instance", () => {
     expect(mockRelationalFilter.filters).toBeUndefined();
@@ -63,6 +68,14 @@ describe("Filter", () => {
     expect(mockConditionalFilter.toString()).toBe(
       "and(contains(test,1),gt(index,3))"
     );
+  });
+
+  it("should ConditionalFilter toString should work properly with isnull", () => {
+    expect(mockConditionalIsNullFilter.toString()).toBe("isnull(value)");
+  });
+
+  it("should ConditionalFilter toString should work properly with not", () => {
+    expect(mockConditionalIsNullFilter.toString()).toBe("isnot(isnull(value))");
   });
 
   it("should get length of the filters", () => {

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -44,7 +44,7 @@ type TConditionalOperator = ConditionalOperator.OR | ConditionalOperator.AND;
 
 type TRelationalFilter = {
   operator: RelationalOperator;
-  key: string;
+  key?: string;
   value?: unknown;
 };
 

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -29,6 +29,8 @@ enum RelationalOperator {
   GTE = "gte",
   GT = "gt",
   IN = "in",
+  ISNULL = "isnull",
+  NOT = "not",
 }
 
 type TRelationalOperator = RelationalOperator.EQ | RelationalOperator.CONTAINS;
@@ -43,7 +45,7 @@ type TConditionalOperator = ConditionalOperator.OR | ConditionalOperator.AND;
 type TRelationalFilter = {
   operator: RelationalOperator;
   key: string;
-  value: unknown;
+  value?: unknown;
 };
 
 type TConditionalFilter = {

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -31,10 +31,7 @@ function areConditionalParams(
 function areRelationalParams(
   params: TConditionalFilter | TRelationalFilter
 ): params is TRelationalFilter {
-  return (
-    (params as TRelationalFilter).key !== undefined &&
-    (params as TRelationalFilter).value !== undefined
-  );
+  return (params as TRelationalFilter).key !== undefined;
 }
 
 export default class Filter<
@@ -43,7 +40,7 @@ export default class Filter<
   operator: T | undefined;
   filters?: Filter<ConditionalOperator | RelationalOperator>[];
   key?: string;
-  value?: unknown;
+  value: unknown;
 
   constructor(params: TFilterParams<T>) {
     if (areConditionalParams(params)) {
@@ -63,7 +60,11 @@ export default class Filter<
         return `${this.operator}(${this.filters.map((f) => f.toString())})`;
       else return "";
     }
-    return `${this.operator}(${this.key},${this.value})`;
+    if (this.operator === RelationalOperator.ISNULL) {
+      return `${this.operator}(${this.key})`;
+    } else {
+      return `${this.operator}(${this.key},${this.value})`;
+    }
   }
 
   getLength(): number {

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -31,7 +31,14 @@ function areConditionalParams(
 function areRelationalParams(
   params: TConditionalFilter | TRelationalFilter
 ): params is TRelationalFilter {
-  return (params as TRelationalFilter).key !== undefined;
+  if (params.operator === RelationalOperator.ISNULL)
+    return (params as TRelationalFilter).key !== undefined;
+  if (params.operator === RelationalOperator.NOT)
+    return (params as TRelationalFilter).value !== undefined;
+  return (
+    (params as TRelationalFilter).key !== undefined &&
+    (params as TRelationalFilter).value !== undefined
+  );
 }
 
 export default class Filter<
@@ -60,11 +67,11 @@ export default class Filter<
         return `${this.operator}(${this.filters.map((f) => f.toString())})`;
       else return "";
     }
-    if (this.operator === RelationalOperator.ISNULL) {
+    if (this.operator === RelationalOperator.ISNULL)
       return `${this.operator}(${this.key})`;
-    } else {
-      return `${this.operator}(${this.key},${this.value})`;
-    }
+    if (this.operator === RelationalOperator.NOT)
+      return `${this.operator}(${this.value})`;
+    return `${this.operator}(${this.key},${this.value})`;
   }
 
   getLength(): number {


### PR DESCRIPTION
## Description

Create the new isnull and not operator

```
const mockConditionalIsNullFilter = new Filter({
  operator: RelationalOperator.ISNULL,
  key: "value",
});
```
mockConditionalIsNullFilter.toString() -> output: `isnull(value)`

```
const mockConditionalIsNotFilter = new Filter({
  operator: RelationalOperator.NOT,
  value: mockConditionalIsNullFilter.toString(),
});
```
mockConditionalIsNotFilter.toString() -> output: `not(isnull(value))`

## Test

- [x] I have added tests that prove my fix is effective or that my feature works