### PR TITLE
feat: add arke custom function support

### DIFF
--- a/src/__tests__/custom_function.test.ts
+++ b/src/__tests__/custom_function.test.ts
@@ -1,0 +1,58 @@
+import { Client, HTTPStatusCode, THttpClientInstance } from "../index";
+import mockAxios from "axios";
+
+const client = new Client({
+  serverUrl: "http://localhost:4000",
+  project: "test_project",
+});
+
+const ARKE_ID = "ARKE_ID";
+const FUNCTION_NAME = "FUNCTION_NAME";
+const DATA = { key: "value" };
+const CONFIG = { headers: { Authorization: "Bearer token" } };
+
+describe("Client Custom Functions", () => {
+  it("should call get function", async () => {
+    jest.spyOn(mockAxios, "get").mockResolvedValue({
+      status: HTTPStatusCode.Success,
+      data: { content: null },
+    });
+
+    await client.arke.fn.get(ARKE_ID, FUNCTION_NAME, CONFIG);
+
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      `/${ARKE_ID}/function/${FUNCTION_NAME}`,
+      CONFIG
+    );
+  });
+
+  it("should call post function", async () => {
+    jest.spyOn(mockAxios, "post").mockResolvedValue({
+      status: HTTPStatusCode.Success,
+      data: { content: null },
+    });
+
+    await client.arke.fn.post(ARKE_ID, FUNCTION_NAME, DATA, CONFIG);
+
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      `/${ARKE_ID}/function/${FUNCTION_NAME}`,
+      DATA,
+      CONFIG
+    );
+  });
+
+  it("should call put function", async () => {
+    jest.spyOn(mockAxios, "put").mockResolvedValue({
+      status: HTTPStatusCode.Success,
+      data: { content: null },
+    });
+
+    await client.arke.fn.put(ARKE_ID, FUNCTION_NAME, DATA, CONFIG);
+
+    expect(mockAxios.put).toHaveBeenCalledWith(
+      `/${ARKE_ID}/function/${FUNCTION_NAME}`,
+      DATA,
+      CONFIG
+    );
+  });
+});

--- a/src/models/arke.ts
+++ b/src/models/arke.ts
@@ -21,8 +21,10 @@ import {
   TResponse,
   TTopology,
 } from "../types";
+import CustomFunction from "./custom_function";
 
 export default class Arke extends Base {
+  fn: CustomFunction;
   protected declare httpClient: THttpClientInstance;
   /**
    * @param params
@@ -34,6 +36,7 @@ export default class Arke extends Base {
     arke: string;
   }) {
     super({ httpClient, arke: "arke" });
+    this.fn = new CustomFunction({ httpClient });
   }
 
   /**

--- a/src/models/custom_function.ts
+++ b/src/models/custom_function.ts
@@ -1,0 +1,54 @@
+import { THttpClientInstance, TRequestConfig, TResponse } from "../types";
+
+export default class CustomFunction {
+  protected declare httpClient: THttpClientInstance;
+  /**
+   * @param params
+   */
+  constructor({ httpClient }: { httpClient: THttpClientInstance }) {
+    this.httpClient = httpClient;
+  }
+
+  /**
+   * Call a custom function with GET method
+   */
+  get(
+    arkeID: string,
+    functionName: string,
+    config?: TRequestConfig
+  ): Promise<TResponse> {
+    return this.httpClient.get(`/${arkeID}/function/${functionName}`, config);
+  }
+
+  /**
+   * Call a custom function with POST method
+   */
+  post(
+    arkeID: string,
+    functionName: string,
+    data: unknown,
+    config?: TRequestConfig
+  ): Promise<TResponse> {
+    return this.httpClient.post(
+      `/${arkeID}/function/${functionName}`,
+      data,
+      config
+    );
+  }
+
+  /**
+   * Call a custom function with PUT method
+   */
+  put(
+    arkeID: string,
+    functionName: string,
+    data: unknown,
+    config?: TRequestConfig
+  ): Promise<TResponse> {
+    return this.httpClient.put(
+      `/${arkeID}/function/${functionName}`,
+      data,
+      config
+    );
+  }
+}


### PR DESCRIPTION
## Description

Add methods for calling arke custom functions 

- `client.arke.fn.get`
- `client.arke.fn.post`
- `client.arke.fn.put`

## Test

- [x] I have added tests that prove my fix is effective or that my feature works