### PR TITLE
fix: remove console error for React Native

### DIFF
--- a/src/network/api/lib/HttpClient.ts
+++ b/src/network/api/lib/HttpClient.ts
@@ -52,8 +52,6 @@ class HttpClient {
 
           if (session) {
             config.headers.Authorization = `Bearer ${session?.access_token}`;
-          } else {
-            console.error("Session not found");
           }
         }
         if (project && config.headers && !config.headers["Arke-Project-Key"])


### PR DESCRIPTION
## Description

Remove console error for React Native cause it create an unuseful toast error on unauthenticated side (ex. login/signup)

<img width="403" alt="Screenshot 2023-12-13 alle 09 57 27" src="https://github.com/arkemishub/clientjs/assets/81776297/37525373-8a08-4b2d-a568-7d8d483c2236">

Also on web is not necessary

<img width="1512" alt="Screenshot 2023-12-13 alle 09 55 14" src="https://github.com/arkemishub/clientjs/assets/81776297/bd7800f1-a1b3-4c06-91d7-c93bcaef6f16">


