### PR TITLE
fix: extend dynamic types

### DIFF
--- a/.changeset/gorgeous-pumpkins-love.md
+++ b/.changeset/gorgeous-pumpkins-love.md
@@ -1,0 +1,5 @@
+---
+"@arkejs/client": patch
+---
+
+fix: dynamics types on all methods

--- a/packages/client/src/models/base.ts
+++ b/packages/client/src/models/base.ts
@@ -46,56 +46,56 @@ export default class Base {
   /**
    * Creates
    */
-  create(
+  create<T = TUnit>(
     data: TRequestData,
     config?: TRequestConfig
-  ): Promise<TResponse<TUnit>> {
+  ): Promise<TResponse<T>> {
     return this.httpClient.post(`/${this.arke}/unit`, data, config);
   }
 
   /**
    * Gets the base struct
    */
-  baseStruct(config?: TRequestConfig): Promise<TResponse<TStruct>> {
+  baseStruct<T = TStruct>(config?: TRequestConfig): Promise<TResponse<T>> {
     return this.httpClient.get(`/${this.arke}/struct`, config);
   }
 
   /**
    * Gets the struct
    */
-  struct(id: string, config?: TRequestConfig): Promise<TResponse<TStruct>> {
+  struct<T = TStruct>(id: string, config?: TRequestConfig): Promise<TResponse<TStruct>> {
     return this.httpClient.get(`/${id}/struct`, config);
   }
 
   /**
    * Get detail
    */
-  get(id: string, config?: TRequestConfig): Promise<TResponse<TUnit>> {
+  get<T = TUnit>(id: string, config?: TRequestConfig): Promise<TResponse<T>> {
     return this.httpClient.get(`/${this.arke}/unit/${id}`, config);
   }
 
   /**
    * Edits an Arke
    */
-  edit(
+  edit<T = TUnit>(
     id: string,
     data: TRequestData,
     config?: TRequestConfig
-  ): Promise<TResponse<TUnit>> {
+  ): Promise<TResponse<T>> {
     return this.httpClient.put(`/${this.arke}/unit/${id}`, data, config);
   }
 
   /**
    * Deletes an Arke
    */
-  delete(id: string, config?: TRequestConfig): Promise<TResponse> {
+  delete<T = TUnit>(id: string, config?: TRequestConfig): Promise<T> {
     return this.httpClient.delete(`/${this.arke}/unit/${id}`, config);
   }
 
   /**
    * GetAll details
    */
-  getAll(config?: TRequestConfig): Promise<TResponse<TUnit, true>> {
+  getAll<T = TUnit>(config?: TRequestConfig): Promise<TResponse<T, true>> {
     return this.httpClient.get(`/${this.arke}/unit`, config);
   }
 }

--- a/packages/client/src/models/group.ts
+++ b/packages/client/src/models/group.ts
@@ -46,31 +46,31 @@ export default class Group extends Base {
   /**
    * Get groups related Arke list
    */
-  getAllArke(
+  getAllArke<T = TUnit>(
     groupId: string,
     config?: TRequestConfig
-  ): Promise<TResponse<TUnit, true>> {
+  ): Promise<TResponse<T, true>> {
     return this.httpClient.get(`/group/${groupId}/arke`, config);
   }
 
   /**
    * Get groups related Units
    */
-  getAllUnits(
+  getAllUnits<T = TUnit>(
     groupId: string,
     config?: TRequestConfig
-  ): Promise<TResponse<TUnit, true>> {
+  ): Promise<TResponse<T, true>> {
     return this.httpClient.get(`/group/${groupId}/unit`, config);
   }
 
   /**
    * Get groups related Units
    */
-  getUnit(
+  getUnit<T = TUnit>(
     groupId: string,
     unitId: string,
     config?: TRequestConfig
-  ): Promise<TResponse<TUnit>> {
+  ): Promise<TResponse<T>> {
     return this.httpClient.get(`/group/${groupId}/unit/${unitId}`, config);
   }
 

--- a/packages/client/src/models/unit.ts
+++ b/packages/client/src/models/unit.ts
@@ -43,11 +43,11 @@ export default class Unit {
   /**
    * Creates a Unit
    */
-  create(
+  create<T = TUnit>(
     arkeId: string,
     data: TRequestData,
     config?: TRequestConfig
-  ): Promise<TResponse<TUnit>> {
+  ): Promise<TResponse<T>> {
     return this.httpClient.post(`/${arkeId}/unit`, data, config);
   }
 
@@ -66,12 +66,12 @@ export default class Unit {
    * Edits a Unit
    */
 
-  edit(
+  edit<T = TUnit>(
     arkeId: string,
     id: string,
     data: TRequestData,
     config?: TRequestConfig
-  ): Promise<TResponse<TUnit>> {
+  ): Promise<TResponse<T>> {
     return this.httpClient.put(`/${arkeId}/unit/${id}`, data, config);
   }
 
@@ -110,7 +110,7 @@ export default class Unit {
   /**
    * GetAll details
    */
-  search(config?: TRequestConfig): Promise<TResponse<TUnit, true>> {
+  search<T = TUnit>(config?: TRequestConfig): Promise<TResponse<T, true>> {
     return this.httpClient.get(`/unit`, config);
   }
 }

--- a/packages/client/src/types/api.ts
+++ b/packages/client/src/types/api.ts
@@ -17,6 +17,7 @@
 import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
 type THttpClientInstance = AxiosInstance;
+type TGenericResponse = AxiosResponse;
 
 type TRequestData = Record<string, unknown> | FormData;
 
@@ -27,4 +28,4 @@ type TResponse<Data = any, Multiple = false> = AxiosResponse<{
   messages: Record<string, unknown>[];
 }>;
 
-export type { THttpClientInstance, TRequestData, TRequestConfig, TResponse };
+export type { THttpClientInstance, TRequestData, TRequestConfig, TResponse, TGenericResponse };


### PR DESCRIPTION
## Description

All client methods support now the dynamic types for typescript to receive the correct type on response

Usage:
```

interface MyType extends TUnit {
   addititional: any;
}

await client.unit.get<MyType>(...);
await client.unit.getAll<MyType>(...);
```

## Related Issue

#8 

## Test

- [x] I have added tests that prove my fix is effective or that my feature works
