### PR TITLE
fix: remove error log for session

### DIFF
--- a/.changeset/slow-doors-march.md
+++ b/.changeset/slow-doors-march.md
@@ -1,0 +1,5 @@
+---
+"@arkejs/client": patch
+---
+
+remove error log for sessios

--- a/packages/client/src/network/api/lib/HttpClient.ts
+++ b/packages/client/src/network/api/lib/HttpClient.ts
@@ -52,8 +52,6 @@ class HttpClient {
 
           if (session) {
             config.headers.Authorization = `Bearer ${session?.access_token}`;
-          } else {
-            console.error("Session not found");
           }
         }
         if (project && config.headers && !config.headers["Arke-Project-Key"])


### PR DESCRIPTION
## Description

Remove error log for session, it creates many logs for unauthenticated API calls. Not necessary now with public Arke.

<img width="1392" alt="Screenshot 2024-04-17 alle 18 21 53" src="https://github.com/arkemishub/clientjs/assets/81776297/e1090b15-14f4-462b-8a80-ef1874faa1d8">